### PR TITLE
ecshreve/sfmta improvements

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,5 +1,0 @@
-version: 1
-cron:
- - name: "update_sfmta_stops_every_day"
-   url: "/get_sfmta_stops"
-   schedule: "0 8 * * *"


### PR DESCRIPTION
# Summary of changes
The main change was borne out of a "too many connections" error we were seeing in the debug logs. From my investigation this error was related to accessing the s3 bucket where the list of Allowed Stops was stored.

I reworked how we deal with the list of Allowed Stops from the SFMTA. We no longer write the list of Allowed Stops into an s3 bucket for use throughout the lifecycle of the application; rather we write the Allowed Stops into a variable and then read from that variable throughout the lifecycle of the application. 

This variable is updated once per day. The /get_sfmta_stops route is no longer needed. The s3 bucket where these stops were previously stored is not needed either.

Due to our new mechanism for storing and updating the SFMTA Allowed stops we no longer need the cron job to run every morning to update the stops.

I reworked how we send POST requests to the SFMTA. The application was  encountering intermittent DNS related errors sending data to the SFMTA API. I implemented a retry mechanism for these requests, in all cases I examined a single retry is enough to successfully send the data.

There is a route configured that can be used as a healthcheck to confirm that the script is running: /admin/healthcheck. I've update the Samsara SFMTA Integration AWS Setup document to reflect this change.

# Testing
I tested fairly extensively using the SFMTA staging endpoint. Throughout my testing the script did not crash, and the new retry mechanism worked as expected.